### PR TITLE
Deque docs, thread-safety note, tests, benchmarks, and dynamic Makefile benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,113 @@
+# Variables
+GO ?= go
+PKG := ./...
+BENCH ?= .
+RUN ?= .
+MEM ?= -benchmem
+TIME ?= 5s
+COUNT ?= 1
+CPU ?= 8
+TAGS ?=
+EXTRA ?=
+ITER ?=
+TIMEOUT ?= 10m
+VERBOSE ?= false
+CPU_PROFILE ?= cpu.out
+MEM_PROFILE ?= mem.out
+
+.PHONY: all test race coverage bench bench-profile bench-all-profiles flamegraph fmt lint clean help
+
+# Default target
+all: test
+
+# Run all tests
+test:
+	@echo "Running tests for package $(PKG)"
+	$(GO) test -run $(RUN) $(PKG) -v
+
+# Run tests with race detector
+race:
+	@echo "Running tests with race detector..."
+	$(GO) test -race -v $(PKG)
+
+# Run tests with coverage
+coverage:
+	@echo "Running tests with coverage..."
+	$(GO) test -coverprofile=coverage.out $(PKG)
+	$(GO) tool cover -html=coverage.out -o coverage.html
+	@echo "✅ Coverage report: coverage.html"
+
+# Run benchmarks
+bench:
+	@echo "Running benchmarks for package: $(PKG) with BENCH='$(BENCH)'"
+	$(GO) test -run $(RUN) -bench '$(BENCH)' $(MEM) -benchtime=$(TIME) $(ITER) \
+	-count=$(COUNT) -cpu $(CPU) -tags '$(TAGS)' -timeout $(TIMEOUT) $(EXTRA) $(PKG)
+
+# Profiled benchmarks (single package only)
+bench-profile:
+	@if [ "$(PKG)" = "./..." ]; then \
+		echo "❌ Error: Cannot use bench-profile with multiple packages (./...). Set PKG to a single package (e.g., ./treemap)"; \
+		exit 1; \
+	fi
+	@echo "Running profiled benchmarks:"
+	@echo "  Package: $(PKG)"
+	@echo "  Benchmark: $(BENCH)"
+	@echo "  Time: $(TIME), Count: $(COUNT), CPU: $(CPU)"
+	$(GO) test -run $(RUN) -bench '$(BENCH)' $(MEM) -benchtime=$(TIME) $(ITER) \
+	-count=$(COUNT) -cpuprofile $(CPU_PROFILE) -memprofile $(MEM_PROFILE) \
+	-cpu $(CPU) -tags '$(TAGS)' -timeout $(TIMEOUT) $(EXTRA) $(PKG)
+	@echo "✅ CPU profile saved to $(CPU_PROFILE)"
+	@echo "✅ Memory profile saved to $(MEM_PROFILE)"
+
+# Profile all packages (each gets separate files)
+bench-all-profiles:
+	@echo "Running profiled benchmarks for ALL packages..."
+	@for pkg in $$(go list ./...); do \
+		f=$$(echo $$pkg | tr / _); \
+		echo "Benchmarking $$pkg..."; \
+		$(GO) test -bench $(BENCH) $(MEM) -benchtime=$(TIME) $(ITER) \
+		-count=$(COUNT) -cpuprofile "$${f}_cpu.out" \
+		-memprofile "$${f}_mem.out" \
+		-cpu $(CPU) -tags '$(TAGS)' -timeout $(TIMEOUT) $(EXTRA) $$pkg; \
+	done
+
+# Generate flamegraph using go tool pprof (interactive)
+flamegraph:
+	@echo "Generating flamegraph from $(CPU_PROFILE)..."
+	go tool pprof -http=:8080 $(CPU_PROFILE)
+
+# Format code
+fmt:
+	@echo "Formatting code..."
+	$(GO) fmt $(PKG)
+
+# Lint code (requires golangci-lint)
+lint:
+	@if ! command -v golangci-lint >/dev/null 2>&1; then \
+		echo "❌ golangci-lint not installed. Install: https://golangci-lint.run/usage/install/"; \
+		exit 1; \
+	fi
+	@echo "Running linter..."
+	golangci-lint run
+
+# Clean generated files (profiles, coverage, binaries)
+clean:
+	@echo "Cleaning generated files..."
+	@rm -f $(CPU_PROFILE) $(MEM_PROFILE) coverage.out coverage.html *.test
+	@rm -f *_cpu.out *_mem.out
+	@echo "✅ Clean complete."
+
+# Help
+help:
+	@echo "Makefile targets:"
+	@echo "  all            - Run tests (default)"
+	@echo "  test           - Run tests"
+	@echo "  race           - Run tests with race detector"
+	@echo "  coverage       - Run tests with coverage report"
+	@echo "  bench          - Run benchmarks (customize with PKG, BENCH, TIME, COUNT, etc.)"
+	@echo "  bench-profile  - Run benchmarks with CPU/mem profiles (cpu.out, mem.out)"
+	@echo "  bench-all-profiles - Profile all packages"
+	@echo "  flamegraph     - Open interactive flamegraph on :8080"
+	@echo "  fmt            - Format code"
+	@echo "  lint           - Run linter (golangci-lint)"
+	@echo "  clean          - Clean generated files"

--- a/deque/deque.go
+++ b/deque/deque.go
@@ -1,0 +1,77 @@
+// Package deque provides a generic double-ended queue (deque) implementation.
+// A Deque allows insertion and removal at both the front and the back in O(1) time.
+package deque
+
+import "github.com/Zubayear/sonic/linkedlist"
+
+// Deque is a generic double-ended queue backed by a doubly linked structure.
+// It supports adding, removing, and peeking elements from both ends in O(1) time.
+// Concurrency: All methods on Deque are safe for concurrent use.
+type Deque[T comparable] struct {
+	data linkedlist.DoublyLinkedList[T]
+}
+
+// OfferFirst inserts the specified element at the front of the deque.
+// Returns true on success along with a nil error.
+// Time Complexity: O(1)
+func (d *Deque[T]) OfferFirst(elem T) (bool, error) {
+	return d.data.AddFirst(elem)
+}
+
+// PollFirst retrieves and removes the first element of the deque.
+// Returns the zero value of T and a non-nil error if the deque is empty.
+// Time Complexity: O(1)
+func (d *Deque[T]) PollFirst() (T, error) {
+	return d.data.RemoveFirst()
+}
+
+// PeekFirst retrieves, but does not remove, the first element of the deque.
+// Returns the zero value of T and a non-nil error if the deque is empty.
+// Time Complexity: O(1)
+func (d *Deque[T]) PeekFirst() (T, error) {
+	return d.data.PeekFirst()
+}
+
+// OfferLast inserts the specified element at the end of the deque.
+// Returns true on success along with a nil error.
+// Time Complexity: O(1)
+func (d *Deque[T]) OfferLast(elem T) (bool, error) {
+	return d.data.AddLast(elem)
+}
+
+// PollLast retrieves and removes the last element of the deque.
+// Returns the zero value of T and a non-nil error if the deque is empty.
+// Time Complexity: O(1)
+func (d *Deque[T]) PollLast() (T, error) {
+	return d.data.RemoveLast()
+}
+
+// PeekLast retrieves, but does not remove, the last element of the deque.
+// Returns the zero value of T and a non-nil error if the deque is empty.
+// Time Complexity: O(1)
+func (d *Deque[T]) PeekLast() (T, error) {
+	return d.data.PeekLast()
+}
+
+// Remove deletes the first occurrence of the specified element from the deque.
+// It returns true if an element was removed, or false otherwise.
+// Time Complexity: O(n)
+func (d *Deque[T]) Remove(elem T) bool {
+	ok, err := d.data.Remove(elem)
+	if err != nil {
+		return false
+	}
+	return ok == elem
+}
+
+// Size returns the number of elements in the deque.
+// Time Complexity: O(1)
+func (d *Deque[T]) Size() int {
+	return d.data.Size()
+}
+
+// IsEmpty reports whether the deque has no elements.
+// Time Complexity: O(1)
+func (d *Deque[T]) IsEmpty() bool {
+	return d.data.IsEmpty()
+}

--- a/deque/deque_bench_test.go
+++ b/deque/deque_bench_test.go
@@ -1,0 +1,258 @@
+package deque
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// Benchmark OfferFirst on a growing deque.
+func BenchmarkOfferFirst(b *testing.B) {
+	var d Deque[int]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.OfferFirst(i); err != nil {
+			b.Fatalf("OfferFirst error: %v", err)
+		}
+	}
+}
+
+// Benchmark OfferLast on a growing deque.
+func BenchmarkOfferLast(b *testing.B) {
+	var d Deque[int]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.OfferLast(i); err != nil {
+			b.Fatalf("OfferLast error: %v", err)
+		}
+	}
+}
+
+// Benchmark PollFirst by preloading then draining exactly b.N elements.
+func BenchmarkPollFirst(b *testing.B) {
+	var d Deque[int]
+	for i := 0; i < b.N; i++ {
+		if _, err := d.OfferLast(i); err != nil {
+			b.Fatalf("OfferLast preload error: %v", err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.PollFirst(); err != nil {
+			b.Fatalf("PollFirst error at i=%d: %v", i, err)
+		}
+	}
+}
+
+// Benchmark PollLast by preloading then draining exactly b.N elements.
+func BenchmarkPollLast(b *testing.B) {
+	var d Deque[int]
+	for i := 0; i < b.N; i++ {
+		if _, err := d.OfferLast(i); err != nil {
+			b.Fatalf("OfferLast preload error: %v", err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.PollLast(); err != nil {
+			b.Fatalf("PollLast error at i=%d: %v", i, err)
+		}
+	}
+}
+
+// Benchmark PeekFirst; maintains at least one element to avoid errors.
+func BenchmarkPeekFirst(b *testing.B) {
+	var d Deque[int]
+	if _, err := d.OfferLast(1); err != nil {
+		b.Fatalf("OfferLast preload error: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.PeekFirst(); err != nil {
+			b.Fatalf("PeekFirst error: %v", err)
+		}
+	}
+}
+
+// Benchmark PeekLast; maintains at least one element to avoid errors.
+func BenchmarkPeekLast(b *testing.B) {
+	var d Deque[int]
+	if _, err := d.OfferLast(1); err != nil {
+		b.Fatalf("OfferLast preload error: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.PeekLast(); err != nil {
+			b.Fatalf("PeekLast error: %v", err)
+		}
+	}
+}
+
+// Benchmark a mixed workload: alternating front/back push and pop.
+func BenchmarkMixed(b *testing.B) {
+	var d Deque[int]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%2 == 0 {
+			if _, err := d.OfferFirst(i); err != nil {
+				b.Fatalf("OfferFirst error: %v", err)
+			}
+		} else {
+			if _, err := d.OfferLast(i); err != nil {
+				b.Fatalf("OfferLast error: %v", err)
+			}
+		}
+		// Keep size bounded to avoid unbounded growth.
+		if d.Size() > 0 && i%3 == 0 {
+			if i%2 == 0 {
+				if _, err := d.PollLast(); err != nil {
+					b.Fatalf("PollLast error: %v", err)
+				}
+			} else {
+				if _, err := d.PollFirst(); err != nil {
+					b.Fatalf("PollFirst error: %v", err)
+				}
+			}
+		}
+	}
+}
+
+// Parallel benchmark for OfferFirst/OfferLast on a shared deque.
+func BenchmarkOfferParallel(b *testing.B) {
+	var d Deque[int]
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		x := 0
+		for pb.Next() {
+			// Alternate ends to exercise both code paths under contention.
+			if x%2 == 0 {
+				if _, err := d.OfferFirst(x); err != nil {
+					b.Fatalf("OfferFirst error: %v", err)
+				}
+			} else {
+				if _, err := d.OfferLast(x); err != nil {
+					b.Fatalf("OfferLast error: %v", err)
+				}
+			}
+			x++
+		}
+	})
+}
+
+// Parallel mixed producer/consumer: each iteration does one push and one pop to avoid emptiness.
+func BenchmarkParallelMixed(b *testing.B) {
+	var d Deque[int]
+	// Preload a small buffer to reduce initial empty errors.
+	for i := 0; i < 1024; i++ {
+		_, _ = d.OfferLast(i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			// One offer and one poll per iteration to keep the deque balanced.
+			if i%2 == 0 {
+				_, _ = d.OfferFirst(i)
+				if _, err := d.PollLast(); err != nil {
+					// If empty due to races, compensate with an extra offer.
+					_, _ = d.OfferLast(i)
+				}
+			} else {
+				_, _ = d.OfferLast(i)
+				if _, err := d.PollFirst(); err != nil {
+					_, _ = d.OfferFirst(i)
+				}
+			}
+			i++
+		}
+	})
+}
+
+// Benchmark Remove for present and absent keys using strings to avoid integer equality shortcuts.
+func BenchmarkRemove(b *testing.B) {
+	var d Deque[string]
+	// Preload with duplicates and a target key.
+	for i := 0; i < 10000; i++ {
+		_, _ = d.OfferLast("k" + strconv.Itoa(i%100))
+	}
+	// Ensure target exists many times.
+	target := "k42"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%2 == 0 {
+			_ = d.Remove(target) // likely true
+			_, _ = d.OfferLast(target)
+		} else {
+			_ = d.Remove("absent-key") // false path
+		}
+	}
+}
+
+// Benchmark Size and IsEmpty for overhead.
+func BenchmarkSizeIsEmpty(b *testing.B) {
+	var d Deque[int]
+	var sink int
+	var sinkBool bool
+	_, _ = d.OfferLast(1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink += d.Size()
+		sinkBool = d.IsEmpty()
+		if sinkBool {
+			_, _ = d.OfferLast(i)
+		}
+	}
+	_ = sink
+	_ = sinkBool
+}
+
+// Optional: benchmark under mild contention with coordinated producers and consumers.
+func BenchmarkCoordinatedParallel(b *testing.B) {
+	var d Deque[int]
+	var wg sync.WaitGroup
+	iters := b.N
+
+	producers := 4
+	consumers := 4
+	itemsPerProducer := iters / producers
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	wg.Add(producers)
+	for p := 0; p < producers; p++ {
+		go func(offset int) {
+			defer wg.Done()
+			for i := 0; i < itemsPerProducer; i++ {
+				_, _ = d.OfferLast(offset + i)
+			}
+		}(p * itemsPerProducer)
+	}
+
+	wg.Add(consumers)
+	for c := 0; c < consumers; c++ {
+		go func() {
+			defer wg.Done()
+			drained := 0
+			for drained < itemsPerProducer {
+				if _, err := d.PollFirst(); err == nil {
+					drained++
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/deque/deque_test.go
+++ b/deque/deque_test.go
@@ -1,0 +1,310 @@
+package deque
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestZeroValueDeque ensures the zero value is usable and returns errors on empty ops.
+func TestZeroValueDeque(t *testing.T) {
+	var d Deque[int]
+
+	if !d.IsEmpty() {
+		t.Fatalf("expected zero-value deque to be empty")
+	}
+	if d.Size() != 0 {
+		t.Fatalf("expected size 0, got %d", d.Size())
+	}
+
+	if _, err := d.PeekFirst(); err == nil {
+		t.Fatalf("expected error on PeekFirst for empty deque")
+	}
+	if _, err := d.PeekLast(); err == nil {
+		t.Fatalf("expected error on PeekLast for empty deque")
+	}
+	if _, err := d.PollFirst(); err == nil {
+		t.Fatalf("expected error on PollFirst for empty deque")
+	}
+	if _, err := d.PollLast(); err == nil {
+		t.Fatalf("expected error on PollLast for empty deque")
+	}
+}
+
+// TestOfferAndPollFirst verifies front insertions and removals.
+func TestOfferAndPollFirst(t *testing.T) {
+	var d Deque[int]
+
+	if ok, err := d.OfferFirst(1); !ok || err != nil {
+		t.Fatalf("OfferFirst failed: ok=%v err=%v", ok, err)
+	}
+	if ok, err := d.OfferFirst(2); !ok || err != nil {
+		t.Fatalf("OfferFirst failed: ok=%v err=%v", ok, err)
+	}
+	if d.Size() != 2 {
+		t.Fatalf("expected size 2, got %d", d.Size())
+	}
+
+	// LIFO from the front
+	v, err := d.PollFirst()
+	if err != nil || v != 2 {
+		t.Fatalf("PollFirst expected 2, got %v err=%v", v, err)
+	}
+	v, err = d.PollFirst()
+	if err != nil || v != 1 {
+		t.Fatalf("PollFirst expected 1, got %v err=%v", v, err)
+	}
+
+	if !d.IsEmpty() || d.Size() != 0 {
+		t.Fatalf("expected empty deque after removals")
+	}
+}
+
+// TestOfferAndPollLast verifies back insertions and removals.
+func TestOfferAndPollLast(t *testing.T) {
+	var d Deque[int]
+
+	if ok, err := d.OfferLast(1); !ok || err != nil {
+		t.Fatalf("OfferLast failed: ok=%v err=%v", ok, err)
+	}
+	if ok, err := d.OfferLast(2); !ok || err != nil {
+		t.Fatalf("OfferLast failed: ok=%v err=%v", ok, err)
+	}
+	if d.Size() != 2 {
+		t.Fatalf("expected size 2, got %d", d.Size())
+	}
+
+	// LIFO from the back
+	v, err := d.PollLast()
+	if err != nil || v != 2 {
+		t.Fatalf("PollLast expected 2, got %v err=%v", v, err)
+	}
+	v, err = d.PollLast()
+	if err != nil || v != 1 {
+		t.Fatalf("PollLast expected 1, got %v err=%v", v, err)
+	}
+}
+
+// TestMixedOperations tests a sequence of mixed operations and peek behavior.
+func TestMixedOperations(t *testing.T) {
+	var d Deque[string]
+
+	must := func(ok bool, err error) {
+		if !ok || err != nil {
+			t.Fatalf("operation failed: ok=%v err=%v", ok, err)
+		}
+	}
+
+	must(d.OfferFirst("b"))
+	must(d.OfferLast("c"))
+	must(d.OfferFirst("a")) // deque: a, b, c
+
+	if s := d.Size(); s != 3 {
+		t.Fatalf("expected size 3, got %d", s)
+	}
+
+	first, err := d.PeekFirst()
+	if err != nil || first != "a" {
+		t.Fatalf("PeekFirst expected 'a', got %q err=%v", first, err)
+	}
+	last, err := d.PeekLast()
+	if err != nil || last != "c" {
+		t.Fatalf("PeekLast expected 'c', got %q err=%v", last, err)
+	}
+
+	// Peeks do not change size
+	if s := d.Size(); s != 3 {
+		t.Fatalf("expected size 3 after peeks, got %d", s)
+	}
+
+	// Remove from both ends
+	v, err := d.PollFirst()
+	if err != nil || v != "a" {
+		t.Fatalf("PollFirst expected 'a', got %q err=%v", v, err)
+	}
+	v, err = d.PollLast()
+	if err != nil || v != "c" {
+		t.Fatalf("PollLast expected 'c', got %q err=%v", v, err)
+	}
+
+	// Only "b" remains
+	v, err = d.PeekFirst()
+	if err != nil || v != "b" {
+		t.Fatalf("PeekFirst expected 'b', got %q err=%v", v, err)
+	}
+	v, err = d.PeekLast()
+	if err != nil || v != "b" {
+		t.Fatalf("PeekLast expected 'b', got %q err=%v", v, err)
+	}
+	v, err = d.PollFirst()
+	if err != nil || v != "b" {
+		t.Fatalf("PollFirst expected 'b', got %q err=%v", v, err)
+	}
+
+	if !d.IsEmpty() || d.Size() != 0 {
+		t.Fatalf("expected empty deque at end")
+	}
+}
+
+// TestRemoveExistingAndNonExisting verifies Remove behavior for present/absent items.
+func TestRemoveExistingAndNonExisting(t *testing.T) {
+	var d Deque[int]
+
+	// Add elements including zero value to exercise edge cases.
+	if ok, err := d.OfferLast(0); !ok || err != nil {
+		t.Fatalf("OfferLast failed for 0: ok=%v err=%v", ok, err)
+	}
+	if ok, err := d.OfferLast(1); !ok || err != nil {
+		t.Fatalf("OfferLast failed for 1: ok=%v err=%v", ok, err)
+	}
+	if ok, err := d.OfferLast(2); !ok || err != nil {
+		t.Fatalf("OfferLast failed for 2: ok=%v err=%v", ok, err)
+	}
+
+	// Remove existing values should return true.
+	if removed := d.Remove(1); !removed {
+		t.Fatalf("Remove(1) expected true, got false")
+	}
+	if d.Size() != 2 {
+		t.Fatalf("expected size 2 after removal, got %d", d.Size())
+	}
+	if removed := d.Remove(0); !removed {
+		t.Fatalf("Remove(0) expected true (existing zero value), got false")
+	}
+
+	// Removing non-existing value should return false.
+	if removed := d.Remove(42); removed {
+		t.Fatalf("Remove(42) expected false, got true")
+	}
+
+	// Removing zero value again should return false.
+	if removed := d.Remove(0); removed {
+		t.Fatalf("Remove(0) expected false when not present, got true")
+	}
+}
+
+// TestErrorsOnEmptyAfterDrains ensures error paths after draining the deque.
+func TestErrorsOnEmptyAfterDrains(t *testing.T) {
+	var d Deque[int]
+	_, _ = d.OfferFirst(10)
+	_, _ = d.OfferLast(20)
+	_, _ = d.PollFirst()
+	_, _ = d.PollLast()
+
+	if !d.IsEmpty() {
+		t.Fatalf("expected empty after draining")
+	}
+	if _, err := d.PollFirst(); err == nil {
+		t.Fatalf("expected error on PollFirst after draining")
+	}
+	if _, err := d.PollLast(); err == nil {
+		t.Fatalf("expected error on PollLast after draining")
+	}
+	if _, err := d.PeekFirst(); err == nil {
+		t.Fatalf("expected error on PeekFirst after draining")
+	}
+	if _, err := d.PeekLast(); err == nil {
+		t.Fatalf("expected error on PeekLast after draining")
+	}
+}
+
+func TestConcurrency(t *testing.T) {
+	const (
+		producers   = 8
+		consumers   = 8
+		perProducer = 1000
+	)
+	total := producers * perProducer
+
+	var d Deque[int]
+	var consumed int64
+
+	var wgProducers sync.WaitGroup
+	wgProducers.Add(producers)
+
+	// Start producers (half OfferFirst, half OfferLast).
+	for p := 0; p < producers; p++ {
+		p := p
+		go func() {
+			defer wgProducers.Done()
+			start := p * perProducer
+			for i := 0; i < perProducer; i++ {
+				val := start + i
+				if p%2 == 0 {
+					if _, err := d.OfferFirst(val); err != nil {
+						t.Errorf("OfferFirst error: %v", err)
+					}
+				} else {
+					if _, err := d.OfferLast(val); err != nil {
+						t.Errorf("OfferLast error: %v", err)
+					}
+				}
+			}
+		}()
+	}
+
+	var producersDone int32
+	go func() {
+		wgProducers.Wait()
+		atomic.StoreInt32(&producersDone, 1)
+	}()
+
+	var wgConsumers sync.WaitGroup
+	wgConsumers.Add(consumers)
+
+	for c := 0; c < consumers; c++ {
+		go func() {
+			defer wgConsumers.Done()
+			for {
+				// First try from front.
+				if _, err := d.PollFirst(); err == nil {
+					if atomic.AddInt64(&consumed, 1) == int64(total) {
+						return
+					}
+					continue
+				}
+				// Then try from back.
+				if _, err := d.PollLast(); err == nil {
+					if atomic.AddInt64(&consumed, 1) == int64(total) {
+						return
+					}
+					continue
+				}
+				// If nothing to consume:
+				// - If producers finished and deque is empty, we're done.
+				if atomic.LoadInt32(&producersDone) == 1 && d.IsEmpty() {
+					return
+				}
+				// Yield to reduce busy-wait pressure.
+				runtime.Gosched()
+			}
+		}()
+	}
+
+	// Global timeout to avoid hanging the test.
+	timeout := time.After(10 * time.Second)
+
+	// Wait until all consumers complete or timeout fires.
+	done := make(chan struct{})
+	go func() {
+		wgConsumers.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Completed
+	case <-timeout:
+		t.Fatalf("TestConcurrency timed out")
+	}
+
+	// Validate results.
+	if got := int(atomic.LoadInt64(&consumed)); got != total {
+		t.Fatalf("consumed %d items; expected %d", got, total)
+	}
+	if !d.IsEmpty() || d.Size() != 0 {
+		t.Fatalf("expected deque to be empty at the end; size=%d", d.Size())
+	}
+}


### PR DESCRIPTION
- Added clear GoDoc for deque with time complexities and explicit thread-safety note.
- Implemented comprehensive tests (edge cases, mixed ops, remove paths).
- Added robust concurrency test with proper termination and timeout.
- Introduced benchmarks (single-threaded, mixed, parallel) with benchmem.
- Enhanced Makefile to run benchmarks for a specific package via argument.