### PR TITLE
fix: resolve concurrency and correctness bugs across collections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
         uses: golangci/golangci-lint-action@f08454af877ea2a5246a58683951857b61853eab
         with:
           version: latest
-      - name: Run tests
-        run: go test ./...
+      - name: Run tests (with race detector)
+        run: go test -race ./...
   codespell:
     name: Check for spelling
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ It is designed to help Go developers stop reinventing the wheel by providing pro
   - `LinkedList`
   - `Set`
 - Tree structures:
-  - `TreeMap(Red-Black Tree/AVL Tree)`
   - `Trie`
 - Priority structures:
   - `PriorityQueue(Binary Heap)` (min & max)
@@ -41,18 +40,20 @@ package main
 
 import (
     "fmt"
-    "github.com/Zubayear/ryushin"
+
+    "github.com/Zubayear/ryushin/trie"
 )
 
 func main() {
-    tr := NewTrie()
+    tr := trie.NewTrie()
 
-	words := []string{"hello", "helium", "he", "hero"}
-	for _, w := range words {
-		tr.Insert(w)
-	}
-	
-	ok := tr.Search("hello")
+    words := []string{"hello", "helium", "he", "hero"}
+    for _, w := range words {
+        tr.Insert(w)
+    }
+
+    ok := tr.Search("hello")
+    fmt.Println(ok) // true
 }
 ```
 

--- a/deque/deque.go
+++ b/deque/deque.go
@@ -95,11 +95,8 @@ func (d *Deque[T]) PeekLast() (T, error) {
 //
 // Time Complexity: O(n)
 func (d *Deque[T]) Remove(elem T) bool {
-	ok, err := d.data.Remove(elem)
-	if err != nil {
-		return false
-	}
-	return ok == elem
+	_, err := d.data.Remove(elem)
+	return err == nil
 }
 
 // Size returns the number of elements in the deque.

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f h1:99ci1mjWVBWwJiEKYY6jWa4d2nTQVIEhZIptnrVb1XY=
-golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b h1:DXr+pvt3nC887026GRP39Ej11UATqWDmWuS99x26cD0=
 golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b/go.mod h1:4QTo5u+SEIbbKW1RacMZq1YEfOBqeXa19JeshGi+zc4=

--- a/linkedlist/linked_list.go
+++ b/linkedlist/linked_list.go
@@ -120,6 +120,11 @@ func (dl *DoublyLinkedList[T]) Add(elem T) (bool, error) {
 func (dl *DoublyLinkedList[T]) AddLast(elem T) (bool, error) {
 	dl.mutex.Lock()
 	defer dl.mutex.Unlock()
+	return dl.addLast(elem)
+}
+
+// addLast inserts an element at the tail. The caller must hold dl.mutex.
+func (dl *DoublyLinkedList[T]) addLast(elem T) (bool, error) {
 	if dl.size == 0 {
 		node := NewListNode(elem, nil, nil)
 		dl.head = node
@@ -137,6 +142,11 @@ func (dl *DoublyLinkedList[T]) AddLast(elem T) (bool, error) {
 func (dl *DoublyLinkedList[T]) AddFirst(elem T) (bool, error) {
 	dl.mutex.Lock()
 	defer dl.mutex.Unlock()
+	return dl.addFirst(elem)
+}
+
+// addFirst inserts an element at the head. The caller must hold dl.mutex.
+func (dl *DoublyLinkedList[T]) addFirst(elem T) (bool, error) {
 	if dl.size == 0 {
 		node := NewListNode(elem, nil, nil)
 		dl.head = node
@@ -155,14 +165,16 @@ func (dl *DoublyLinkedList[T]) AddFirst(elem T) (bool, error) {
 //
 // Time Complexity: O(n)
 func (dl *DoublyLinkedList[T]) AddAt(idx int, elem T) (bool, error) {
+	dl.mutex.Lock()
+	defer dl.mutex.Unlock()
 	if idx < 0 || idx > dl.size {
 		return false, errors.New("invalid index")
 	}
 	if idx == 0 {
-		return dl.AddFirst(elem)
+		return dl.addFirst(elem)
 	}
 	if idx == dl.size {
-		return dl.AddLast(elem)
+		return dl.addLast(elem)
 	}
 	temp := dl.head
 
@@ -205,6 +217,11 @@ func (dl *DoublyLinkedList[T]) PeekLast() (T, error) {
 func (dl *DoublyLinkedList[T]) RemoveFirst() (T, error) {
 	dl.mutex.Lock()
 	defer dl.mutex.Unlock()
+	return dl.removeFirst()
+}
+
+// removeFirst deletes and returns the head element. The caller must hold dl.mutex.
+func (dl *DoublyLinkedList[T]) removeFirst() (T, error) {
 	var zero T
 	if dl.size == 0 {
 		return zero, errors.New("linked list empty")
@@ -224,6 +241,11 @@ func (dl *DoublyLinkedList[T]) RemoveFirst() (T, error) {
 func (dl *DoublyLinkedList[T]) RemoveLast() (T, error) {
 	dl.mutex.Lock()
 	defer dl.mutex.Unlock()
+	return dl.removeLast()
+}
+
+// removeLast deletes and returns the tail element. The caller must hold dl.mutex.
+func (dl *DoublyLinkedList[T]) removeLast() (T, error) {
 	var zero T
 	if dl.size == 0 {
 		return zero, errors.New("linked list empty")
@@ -239,13 +261,14 @@ func (dl *DoublyLinkedList[T]) RemoveLast() (T, error) {
 	return value, nil
 }
 
-// removeNode deletes a given node from the list and relink neighbors. O(1)
+// removeNode deletes a given node from the list and relinks neighbors. O(1)
+// The caller must hold dl.mutex.
 func (dl *DoublyLinkedList[T]) removeNode(node *ListNode[T]) (T, error) {
 	if node.prev == nil {
-		return dl.RemoveFirst()
+		return dl.removeFirst()
 	}
 	if node.next == nil {
-		return dl.RemoveLast()
+		return dl.removeLast()
 	}
 	node.next.prev = node.prev
 	node.prev.next = node.next
@@ -258,6 +281,8 @@ func (dl *DoublyLinkedList[T]) removeNode(node *ListNode[T]) (T, error) {
 
 // Remove deletes the first occurrence of a given element. O(n)
 func (dl *DoublyLinkedList[T]) Remove(elem T) (T, error) {
+	dl.mutex.Lock()
+	defer dl.mutex.Unlock()
 	var zero T
 	if dl.size == 0 {
 		return zero, errors.New("linked list empty")
@@ -273,6 +298,8 @@ func (dl *DoublyLinkedList[T]) Remove(elem T) (T, error) {
 
 // RemoveAt removes and returns the element at a specific index. O(n)
 func (dl *DoublyLinkedList[T]) RemoveAt(idx int) (T, error) {
+	dl.mutex.Lock()
+	defer dl.mutex.Unlock()
 	var zero T
 	if idx < 0 || idx >= dl.size {
 		return zero, errors.New("invalid index")
@@ -324,16 +351,24 @@ func (dl *DoublyLinkedList[T]) Contains(elem T) (bool, error) {
 }
 
 // Iterate returns a channel-based iterator for traversing the list.
+//
+// It takes a point-in-time snapshot under the read lock and releases the lock
+// before streaming. This avoids holding dl.mutex for the lifetime of the
+// iteration, which would otherwise deadlock writers if the consumer stopped
+// reading the channel early.
 func (dl *DoublyLinkedList[T]) Iterate() Iterator[T] {
+	dl.mutex.RLock()
+	snapshot := make([]T, 0, dl.size)
+	for iterNode := dl.head; iterNode != nil; iterNode = iterNode.next {
+		snapshot = append(snapshot, iterNode.val)
+	}
+	dl.mutex.RUnlock()
+
 	iterChan := make(chan T)
 	go func() {
-		dl.mutex.RLock()
-		defer dl.mutex.RUnlock()
 		defer close(iterChan)
-		iterNode := dl.head
-		for iterNode != nil {
-			iterChan <- iterNode.val
-			iterNode = iterNode.next
+		for _, v := range snapshot {
+			iterChan <- v
 		}
 	}()
 	return iterChan

--- a/linkedlist/regression_test.go
+++ b/linkedlist/regression_test.go
@@ -1,0 +1,60 @@
+package linkedlist
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentMutationRace guards the regression where AddAt/Remove/RemoveAt
+// and the middle-node path of removeNode mutated the list without holding the
+// lock. Run with -race.
+func TestConcurrentMutationRace(t *testing.T) {
+	dl := NewLinkedList[int]()
+	for i := 0; i < 1000; i++ {
+		dl.AddLast(i)
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				dl.AddAt(1, base+i)
+				dl.Remove(base + i)
+				dl.RemoveAt(0)
+				dl.AddFirst(base + i)
+			}
+		}(g * 1000000)
+	}
+	wg.Wait()
+}
+
+// TestIterateEarlyBreakDoesNotDeadlock guards the regression where Iterate held
+// the read lock for the lifetime of the streaming goroutine. A consumer that
+// stops reading early must not block subsequent writers.
+func TestIterateEarlyBreakDoesNotDeadlock(t *testing.T) {
+	dl := NewLinkedList[int]()
+	for i := 0; i < 100; i++ {
+		dl.AddLast(i)
+	}
+
+	// Read a single value then abandon the iterator.
+	it := dl.Iterate()
+	<-it
+
+	done := make(chan struct{})
+	go func() {
+		// These take the write lock; they must not block on a held read lock.
+		dl.AddLast(999)
+		_, _ = dl.RemoveFirst()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("DEADLOCK: writer blocked after iterator consumer stopped early")
+	}
+}

--- a/priorityqueue/binary_heap.go
+++ b/priorityqueue/binary_heap.go
@@ -1,8 +1,10 @@
 /*
-Package priorityqueue provides a generic, thread-safe binary max-heap(default) implementation in Go.
+Package priorityqueue provides a generic, thread-safe binary heap implementation in Go.
 
-A BinaryHeap is a priority queue where the smallest element is always at the root.
-It supports insertion, retrieval of the minimum element, and removal while maintaining
+By default a BinaryHeap is a max-heap: the largest element (per the natural ordering
+of T) is always at the root. Supplying a custom comparator via
+NewBinaryHeapWithComparator lets you build a min-heap or any other ordering.
+It supports insertion, retrieval of the root element, and removal while maintaining
 the heap property.
 
 The type parameter T must satisfy constraints.Ordered (supports <, > operators).
@@ -150,7 +152,10 @@ func NewBinaryHeapWithComparator[T any](cmp func(a, b T) bool) *BinaryHeap[T] {
 func (bh *BinaryHeap[T]) IsEmpty() bool {
 	bh.mutex.RLock()
 	defer bh.mutex.RUnlock()
-	return bh.Size() == 0
+	// Read len(bh.data) directly rather than calling Size(): sync.RWMutex read
+	// locks are not reentrant, so calling Size() (which also takes RLock) here
+	// can deadlock when a writer is contending for the lock.
+	return len(bh.data) == 0
 }
 
 // Clear removes all elements from the heap.

--- a/priorityqueue/regression_test.go
+++ b/priorityqueue/regression_test.go
@@ -1,0 +1,46 @@
+package priorityqueue
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestIsEmptyConcurrentNoDeadlock guards the regression where IsEmpty() took a
+// read lock and then called Size(), which took the read lock again. sync.RWMutex
+// read locks are not reentrant, so with a contending writer this could deadlock.
+func TestIsEmptyConcurrentNoDeadlock(t *testing.T) {
+	bh := NewBinaryHeap[int]()
+	done := make(chan struct{})
+
+	go func() {
+		var wg sync.WaitGroup
+		for w := 0; w < 4; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 200000; i++ {
+					bh.Add(i)
+					bh.Poll()
+				}
+			}()
+		}
+		for r := 0; r < 8; r++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 200000; i++ {
+					_ = bh.IsEmpty()
+				}
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("DEADLOCK: IsEmpty()+Size() recursive RLock with contending writer")
+	}
+}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -179,6 +179,8 @@ func (q *Queue[T]) IsEmpty() bool {
 //
 // Complexity: O(1)
 func (q *Queue[T]) Size() int {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
 	return q.count
 }
 
@@ -192,8 +194,8 @@ func (q *Queue[T]) Size() int {
 //
 // Complexity: O(n)
 func (q *Queue[T]) ToString() string {
-	q.mutex.Lock()
-	defer q.mutex.Unlock()
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
 	var result strings.Builder
 	result.WriteString("[")
 	for r := q.front; r <= q.rear-1; r++ {
@@ -219,6 +221,7 @@ func (q *Queue[T]) Clear() {
 	q.rear = 0
 	q.count = 0
 	q.cap = 16
+	q.data = make([]T, q.cap)
 }
 
 // ToArray returns a array representation of the queue elements in FIFO order.
@@ -259,9 +262,13 @@ func (q *Queue[T]) Iterator() *Iterator[T] {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
-	// copy snapshot
-	snapshot := make([]T, q.Size())
-	copy(snapshot, q.data)
+	// Copy elements honoring circular order (front..rear) so the snapshot is in
+	// FIFO order. Copying q.data directly would ignore front/rear and yield
+	// stale or zeroed slots after dequeues/wrap-around.
+	snapshot := make([]T, q.count)
+	for i := 0; i < q.count; i++ {
+		snapshot[i] = q.data[(q.front+i)%q.cap]
+	}
 
 	return &Iterator[T]{data: snapshot, idx: 0}
 }

--- a/queue/regression_test.go
+++ b/queue/regression_test.go
@@ -1,0 +1,85 @@
+package queue
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// TestIteratorFIFOAfterWrap guards the regression where Iterator() copied the
+// raw backing array from index 0, ignoring front/rear, so it yielded stale or
+// zeroed slots after dequeues.
+func TestIteratorFIFOAfterWrap(t *testing.T) {
+	q := NewQueue[int]()
+	for i := 0; i < 10; i++ {
+		q.Enqueue(i)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := q.Dequeue(); err != nil {
+			t.Fatalf("dequeue failed: %v", err)
+		}
+	}
+	want := []int{5, 6, 7, 8, 9}
+
+	var got []int
+	it := q.Iterator()
+	for {
+		v, ok := it.Next()
+		if !ok {
+			break
+		}
+		got = append(got, v)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Iterator FIFO mismatch:\n want %v\n got  %v", want, got)
+	}
+}
+
+// TestIteratorMatchesToArray ensures Iterator and ToArray agree, including after
+// a resize triggered while front != 0.
+func TestIteratorMatchesToArray(t *testing.T) {
+	q := NewQueue[int]()
+	for i := 0; i < 8; i++ {
+		q.Enqueue(i)
+	}
+	for i := 0; i < 6; i++ {
+		q.Dequeue()
+	}
+	// Force a resize while front is advanced and wrapped.
+	for i := 100; i < 140; i++ {
+		q.Enqueue(i)
+	}
+
+	want := q.ToArray()
+	var got []int
+	it := q.Iterator()
+	for {
+		v, ok := it.Next()
+		if !ok {
+			break
+		}
+		got = append(got, v)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Iterator vs ToArray mismatch:\n want %v\n got  %v", want, got)
+	}
+}
+
+// TestSizeConcurrent exercises Size alongside writers; run with -race to detect
+// the prior unsynchronized read of count.
+func TestSizeConcurrent(t *testing.T) {
+	q := NewQueue[int]()
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 5000; i++ {
+				q.Enqueue(i)
+				_ = q.Size()
+				q.Dequeue()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/set/unordered_set.go
+++ b/set/unordered_set.go
@@ -95,12 +95,12 @@ func (us *UnorderedSet[T]) Clear() {
 
 // Items return a slice containing all elements in the set.
 // The order of elements is not guaranteed.
-// Algorithm: Iterate over the map keys and append to a slice. Lock acquired for writing.
+// Algorithm: Iterate over the map keys and append to a slice. Read lock acquired.
 //
 // Time Complexity: O(n), where n = number of elements in the set
 func (us *UnorderedSet[T]) Items() []T {
-	us.lockObj.Lock()
-	defer us.lockObj.Unlock()
+	us.lockObj.RLock()
+	defer us.lockObj.RUnlock()
 	elements := make([]T, 0, len(us.items))
 	for element := range us.items {
 		elements = append(elements, element)

--- a/stack/regression_test.go
+++ b/stack/regression_test.go
@@ -1,0 +1,56 @@
+package stack
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestClearThenPushDoesNotPanic guards the regression where Clear() nil-ed the
+// backing slice but left cap unchanged, causing the next Push to index into a
+// nil slice and panic.
+func TestClearThenPushDoesNotPanic(t *testing.T) {
+	s := NewStack[int]()
+	if _, err := s.Push(1); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	s.Clear()
+
+	if _, err := s.Push(2); err != nil {
+		t.Fatalf("Push after Clear failed: %v", err)
+	}
+	v, err := s.Peek()
+	if err != nil {
+		t.Fatalf("Peek after Clear+Push failed: %v", err)
+	}
+	if v != 2 {
+		t.Fatalf("want 2 got %d", v)
+	}
+	if got := s.Size(); got != 1 {
+		t.Fatalf("want size 1 got %d", got)
+	}
+}
+
+// TestPeekConcurrent exercises Peek alongside writers; run with -race to detect
+// the prior unsynchronized read of the backing slice in Peek.
+func TestPeekConcurrent(t *testing.T) {
+	s := NewStack[int]()
+	s.Push(42)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 5000; i++ {
+				if i%2 == 0 {
+					s.Push(i)
+				} else {
+					s.Pop()
+				}
+				_, _ = s.Peek()
+				_ = s.Size()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -142,8 +142,12 @@ func (s *Stack[T]) Pop() (T, error) {
 //
 // Complexity: O(1)
 func (s *Stack[T]) Peek() (T, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	var zero T
-	if s.IsEmpty() {
+	// Inline the emptiness check instead of calling IsEmpty(): RWMutex read
+	// locks are not reentrant and the value read must happen under the same lock.
+	if s.top == -1 {
 		return zero, errors.New("stack empty")
 	}
 	return s.data[s.top], nil
@@ -153,8 +157,8 @@ func (s *Stack[T]) Peek() (T, error) {
 //
 // Complexity: O(1)
 func (s *Stack[T]) Size() int {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	return s.top + 1
 }
 
@@ -203,12 +207,14 @@ func (s *Stack[T]) ValueAt(pos int) (T, error) {
 }
 
 // Clear removes all elements from the stack and resets it to an empty state.
-// After clearing, the underlying slice is set to nil to free memory.
+// The underlying slice is reallocated at the default initial capacity so the
+// stack remains usable (and releases the previously held backing array).
 //
 // Complexity: O(1)
 func (s *Stack[T]) Clear() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	s.cap = 16
 	s.top = -1
-	s.data = nil
+	s.data = make([]T, s.cap)
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -187,7 +187,6 @@ func (t *Trie) Search(word string) bool {
 // Algorithm Steps:
 //   - Traverse the Trie for each character in the prefix.
 //   - If at any point a character is missing, return false.
-//   - If at any point a character is missing, return false.
 //   - If traversal succeeds, return true.
 //
 // Time Complexity: O(K), where K = length of the prefix


### PR DESCRIPTION
# Pull Request

## 📌 Description
The library advertises itself as **concurrency-safe**, but several collections had a deadlock, a panic, data corruption, and data races. This PR fixes them, hardens the read-only paths, and adds regression tests so they can't silently come back.

I confirmed each bug by running throwaway repros against the current code (panic, `[0 0 0 0 0]` from the queue iterator, `-race` failures, and a hung `IsEmpty`) before fixing.

### Critical
- **priorityqueue** — `IsEmpty()` took a read lock and then called `Size()`, which takes the read lock again. `sync.RWMutex` read locks are **not reentrant**, so under writer contention this deadlocks. Now reads `len(bh.data)` directly.
- **stack** — `Clear()` nil-ed `data` but left `cap` set, so the next `Push()` indexed into a nil slice and **panicked**. Now reallocates at the default capacity.
- **queue** — `Iterator()` copied the raw backing array from index 0, ignoring `front`/`rear`, so it returned stale/zeroed elements after any dequeue/wrap-around. Now copies in FIFO order.
- **linkedlist** — `AddAt` / `Remove` / `RemoveAt` and the middle-node path of `removeNode` mutated the list **without holding the lock** (confirmed by `-race`). Refactored to lock once via unlocked internal helpers.

### High
- **stack** — `Peek()` read the slice with no lock held; now holds `RLock` and inlines the empty check. `Size()` used a write lock → `RLock`.
- **queue** — `Size()` was unsynchronized; now takes `RLock`.
- **linkedlist** — `Iterate()` held the read lock for the entire channel drain, deadlocking writers if the consumer stopped early. Now snapshots under the lock and releases before streaming (same pattern as `set.Iter`).
- **docs** — README quick-start didn't compile (wrong import/package); fixed.

### Medium / polish
- CI now runs tests with `-race` (this is why the bugs shipped green).
- `set.Items` / `queue.ToString` use `RLock` for read-only access.
- Corrected the priorityqueue package doc (default is a max-heap) and removed the unimplemented `TreeMap` claim from the README.
- Simplified `deque.Remove`, removed a duplicated trie doc line, and ran `go mod tidy` (dropped a stale `go.sum` entry).

Fixes # (no issue)

---

## ✅ Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Performance improvement
- [ ] Other (please specify):

---

## 🔍 Checklist
- [x] Code follows Go best practices
- [x] Tests added for new features
- [x] All tests pass locally (`make test`)
- [x] Benchmark tests pass locally (`make bench`)
- [x] Documentation updated (if required)

---

## 📝 Additional Context
Added `regression_test.go` in `stack`, `queue`, `linkedlist`, and `priorityqueue` covering each fixed bug (clear+push, FIFO-after-wrap, concurrent-mutation race, iterator early-break, recursive-RLock deadlock). Full suite is green:

```
go test -race ./...
ok  deque  linkedlist  priorityqueue  queue  set  stack  trie
```

Deliberately **not** included (API-breaking; happy to follow up): relaxing `Stack`/`Queue` from `comparable` to `any`, dropping the always-`(true, nil)` returns, and unexporting `NewListNode`/`ListNode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential deadlock issues in LinkedList iteration and concurrent operations
  * Resolved deadlock in BinaryHeap's empty-check under concurrent load
  * Corrected Queue iterator to properly handle wrapped buffers and maintain FIFO order
  * Improved concurrent safety across collection operations

* **Performance Improvements**
  * Optimized read-only operations to use read locks instead of write locks, reducing contention

* **Documentation**
  * Updated README with corrected feature list and usage examples

* **Tests**
  * Added comprehensive regression tests for concurrent safety and edge cases across all collections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->